### PR TITLE
Make InitSearch use kendoAutoComplete for running the search

### DIFF
--- a/_install/Searches/InitSearch.js
+++ b/_install/Searches/InitSearch.js
@@ -3,102 +3,101 @@
 /* ------------ Init Custom Portal Search ------------ */
 /* ----------------------------------------------- */
 // v8.1
-// Contributors: William Udovich, Joivan Hedrick, Geoff Ross, Stefan Henseler, Seth Coussens
+// Contributors: William Udovich, Joivan Hedrick, Geoff Ross, Stefan Henseler, Seth Coussens, Cory Bowe
 /* Description: Adds advanced search functionality to the main search of the portal, SQL style.*/
 
 $(document).ready(function () {
 
-	//Get a reference of the search input text box
-	var searchInput = $("input[name=searchText]");
+    //Get a reference of the search input text box
+    var searchInput = $("input[name=searchText]");
 
-	//Add ID for css formating of the result list
-	searchInput.attr('id', 'searchText');
+    //Add ID for css formating of the result list
+    searchInput.attr('id', 'searchText');
 
-	// Add Software Asset Search Type
-	$(".navbar__search--dropdown ul").append('<li><a id="SoftwareAssetSearchType">Software Asset</a></li>');
-	// Add Hardware Asset Search Type
-	$(".navbar__search--dropdown ul").append('<li><a id="HardwareAssetSearchType">Hardware Asset</a></li>');
-	// Add Hardware Asset Search Type
-	$(".navbar__search--dropdown ul").append('<li><a id="UserSearchType">User</a></li>');
+    // Add Software Asset Search Type
+    $(".navbar__search--dropdown ul").append('<li><a id="SoftwareAssetSearchType">Software Asset</a></li>');
+    // Add Hardware Asset Search Type
+    $(".navbar__search--dropdown ul").append('<li><a id="HardwareAssetSearchType">Hardware Asset</a></li>');
+    // Add Hardware Asset Search Type
+    $(".navbar__search--dropdown ul").append('<li><a id="UserSearchType">User</a></li>');
 
+    function disableSearchKeys() {
+        $("span.navbar__search--btn").hide();
+        $("input[name=searchText]").unbind("keypress");
+    }
 
-	//Add Custom toggle event handling
-	$(".dropdown-menu").on("click", "li", function (event) {
+    //Add Custom toggle event handling
+    $(".dropdown-menu").on("click", "li", function (event) {
 
-		var searchType = event.target.id;
-		//console.log(event);
+        var searchType = event.target.id;
+        //console.log(event);
 
-		// If Autocomplete already exists destroy, just do clean everything up... IT Monkey would love it!!
-		if (searchInput.data("kendoAutoComplete")) {
-			customSearchLib.disableCustomHeaderSearch(searchInput);
-		}
+        // If Autocomplete already exists destroy, just do clean everything up... IT Monkey would love it!!
+        if (searchInput.data("kendoAutoComplete")) {
+            customSearchLib.disableCustomHeaderSearch(searchInput);
+        }
 
-		function disableSearchKeys() {
-			$("span.navbar__search--btn").hide();
-			$("input[name=searchText]").unbind("keypress");
-		}
+        switch (searchType) {
+            case "SoftwareAssetSearchType":
+                customSearchSoftwareAsset.initSearch(searchInput);
+                // Update Search Param and Concept
+                var currentURL = window.location.href;
+                var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
+                var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
+                searchParam.val("SoftwareAsset");
+                searchConcept.html('Software Asset');
+                disableSearchKeys();
+                break;
+            case "HardwareAssetSearchType":
+                customSearchHardwareAsset.initSearch(searchInput);
+                // Update Search Param and Concept
+                var currentURL = window.location.href;
+                var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
+                var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
+                searchParam.val("HardwareAsset");
+                searchConcept.html('Hardware Asset');
+                disableSearchKeys();
+                break;
+            case "UserSearchType":
+                customSearchUser.initSearch(searchInput);
+                // Update Search Param and Concept
+                var currentURL = window.location.href;
+                var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
+                var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
+                searchParam.val("User");
+                searchConcept.html('User');
+                disableSearchKeys();
+                break;
+            default:
+                $("span.navbar__search--btn").show();
+                $("input[name=searchText]").keypress(function (event) {
+                    if (event.keyCode == 13) {
+                        app.headerSearchWorkItem();
+                    }
+                });
+                break;
+        }
+    });
 
-		switch (searchType) {
-			case "SoftwareAssetSearchType":
-				customSearchSoftwareAsset.initSearch(searchInput);
-				// Update Search Param and Concept
-				var currentURL = window.location.href;
-				var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
-				var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
-				searchParam.val("SoftwareAsset");
-				searchConcept.html('Software Asset');
-				disableSearchKeys();
-				break;
-			case "HardwareAssetSearchType":
-				customSearchHardwareAsset.initSearch(searchInput);
-				// Update Search Param and Concept
-				var currentURL = window.location.href;
-				var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
-				var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
-				searchParam.val("HardwareAsset");
-				searchConcept.html('Hardware Asset');
-				disableSearchKeys();
-				break;
-			case "UserSearchType":
-				customSearchUser.initSearch(searchInput);
-				// Update Search Param and Concept
-				var currentURL = window.location.href;
-				var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
-				var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
-				searchParam.val("User");
-				searchConcept.html('User');
-				disableSearchKeys();
-				break;
-			default:
-				$("span.navbar__search--btn").show();
-				$("input[name=searchText]").keypress(function (event) {
-					if (event.keyCode == 13) {
-						app.headerSearchWorkItem();
-					}
-				});
-				break;
-		}
-	});
+    if (typeof customSearchHardwareAsset == "undefined") {
+        app.events.subscribe('customSearchHardwareAssetCreated', function () {
+            init(searchInput)
+        });
+    }
+    else {
+        init(searchInput);
+    }
 
-	if (typeof customSearchHardwareAsset == "undefined") {
-		app.events.subscribe('customSearchHardwareAssetCreated', function () {
-			init(searchInput)
-		});
-	}
-	else {
-		init(searchInput);
-	}
-
-	function init(searchInput) {
-		if (session.user.AssetManager === 1) {
-			customSearchHardwareAsset.initSearch(searchInput);
-			// set Hardware Asset search as default if user is hardware asset manager
-			var currentURL = window.location.href;
-			var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
-			var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
-			searchParam.val("HardwareAsset");
-			searchConcept.html('Hardware Asset');
-
-		}
-	};
+    function init(searchInput) {
+        if (session.user.AssetManager === 1) {
+            customSearchHardwareAsset.initSearch(searchInput);
+            // set Hardware Asset search as default if user is hardware asset manager
+            var currentURL = window.location.href;
+            var searchParam = $("input[name=search_param]"); //the hidden field which holds the search type id
+            var searchConcept = $("span[id=search_concept]"); //the span field which displays the search type value      
+            searchParam.val("HardwareAsset");
+            searchConcept.html('Hardware Asset');
+            disableSearchKeys();
+        }
+    };
 });

--- a/_install/Searches/SearchLib.js
+++ b/_install/Searches/SearchLib.js
@@ -3,7 +3,7 @@
 /* ------------ Advanced Portal Search - Lib ------------ */
 /* ----------------------------------------------------- */
 // v8.1
-// Contributors: William Udovich, Joivan Hedrick, Geoff Ross, Stefan Henseler, Seth Coussens
+// Contributors: William Udovich, Joivan Hedrick, Geoff Ross, Stefan Henseler, Seth Coussens, Cory Bowe
 /* Description: Contains shared code for the advanced portal search */
 
 
@@ -36,12 +36,17 @@ var customSearchLib = {
 			filter: "contains",
 			placeholder: "Please enter a search term ...",
 			minLength: 3,
-			delay: 300,
+			delay: 600,
 			width: 600,
 			height: 800,
 			filtering: function (obj) {		
 				// show progress
-				 kendo.ui.progress($(".navbar__search--input"), true);
+				 if (!obj.filter.value) {
+					//prevent filtering if the filter does not value
+					obj.preventDefault();
+				  } else {
+					kendo.ui.progress($(".navbar__search--input"), true);
+				  }
 			},				
 			dataBound : function (obj) {
 				// hide progress
@@ -116,23 +121,6 @@ var customSearchLib = {
 
 		});
 
-		// Update Search if input box content changes
-		searchInput.on('keyup', function (e) {
-
-			var assetSearchText = searchInput.val(); //Get the value that the user typed in. 
-		
-			//If the autocomplete text is empty, then allow default OOB behavior. Otherwise, disable the OOB mouseout.
-			if (assetSearchText != "" && assetSearchText.length > 2) {
-				searchInput.data("kendoAutoComplete").search(assetSearchText);
-			};
-		});	
-
-		var assetSearchText = searchInput.val(); //Get the value that the user typed in. 
-
-		//force search if box is not empty and has at least a length of 3
-		if (assetSearchText != "" && assetSearchText.length > 2) {
-			searchInput.data("kendoAutoComplete").search(assetSearchText);
-		};
 	},
 
 	// Data Source Init code


### PR DESCRIPTION
The keyup events were taking over when the search was triggered in SearchLib.js.  Moved them to filter function.  In InitSearch.js, when loading the hardwareasset search the first time we weren't running the disable keys function.